### PR TITLE
refactor: 移除 config_env.toml 中的 EMAIL 配置

### DIFF
--- a/config_env.toml
+++ b/config_env.toml
@@ -1,5 +1,0 @@
-[EMAIL]
-USER = "email@gmail.com"
-PASSWORD = "password"
-PORT = 465
-HOST = "smtp.gmail.com"


### PR DESCRIPTION
移除了 config_env.toml 文件中的 [EMAIL] 部分，包括用户、密码、端口和主机信息。